### PR TITLE
Ot284 78

### DIFF
--- a/src/app/features/pages/news/news-cards/news-cards.component.html
+++ b/src/app/features/pages/news/news-cards/news-cards.component.html
@@ -1,4 +1,4 @@
-<h1 [ngStyle]="{'text-align':'center'}">Novedades</h1>
+<app-title [title]="myTitle"></app-title>
 <div class="container">
     <div class="row">
         <div *ngFor="let new of newsLista" class="card">
@@ -16,7 +16,7 @@
                 <div *ngIf="!mostrarFechaAct(new.created_at,new.updated_at)">
                     <p>Fecha de creación: {{new.created_at | date :'dd/MM/yy'}}</p>
                 </div> 
-                <button type="button" (click)="detalleVer(new)" mat-raised-button color="primary">VER DETALLE</button>
+                <button type="button" (click)="detalleVer(new)" mat-raised-button color="warn">VER DETALLE</button>
             </div>
         </div>  
     </div>

--- a/src/app/features/pages/news/news-cards/news-cards.component.html
+++ b/src/app/features/pages/news/news-cards/news-cards.component.html
@@ -1,5 +1,4 @@
 <h1 [ngStyle]="{'text-align':'center'}">Novedades</h1>
-<button mat-raised-button color="primary" [style.margin.px]='10' (click)="crear()">Crear Novedad</button>
 <div class="container">
     <div class="row">
         <div *ngFor="let new of newsLista" class="card">
@@ -17,7 +16,6 @@
                 <div *ngIf="!mostrarFechaAct(new.created_at,new.updated_at)">
                     <p>Fecha de creación: {{new.created_at | date :'dd/MM/yy'}}</p>
                 </div> 
-                <button type="button" (click)="modificar(new)" mat-raised-button color="primary">MODIFICAR</button>
                 <button type="button" (click)="detalleVer(new)" mat-raised-button color="primary">VER DETALLE</button>
             </div>
         </div>  

--- a/src/app/features/pages/news/news-cards/news-cards.component.ts
+++ b/src/app/features/pages/news/news-cards/news-cards.component.ts
@@ -43,14 +43,6 @@ export class NewsCardsComponent implements OnInit {
     }
     return result;
   }
-
-  public modificar(newModel:newData){
-    this.ruta.navigate([`backoffice/news/${newModel.id}`]);
-  }
-  
-  public crear(){
-    this.ruta.navigate(['backoffice/news']);
-  }
   
   public detalleVer(novedad:newData){
     this.ruta.navigate([`novedades/${novedad.id}`]);

--- a/src/app/features/pages/news/news-cards/news-cards.component.ts
+++ b/src/app/features/pages/news/news-cards/news-cards.component.ts
@@ -13,9 +13,9 @@ import { NewsService } from '../news.service';
 export class NewsCardsComponent implements OnInit {
   public newsLista: newData[]=[]
   public newModel!:newData;
-
+  public myTitle:string;
   constructor(private newsService: NewsService, private ruta:Router) {
-    
+    this.myTitle="Novedades";
   }
 
   ngOnInit(): void {

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -26,15 +26,15 @@ export class NewsService {
   }
 
   public deleteNew(id:number):Observable<any>{
-    return this.http.delete<any>(`${this.api}/${id}`);
+    return this.http.delete<any>(environment.endpoints.novedades.delete(id));
   }
   
   public nuevaNew(novedad:Novedad):Observable<Novedad>{
-    return this.http.post<Novedad>(this.api,novedad);
+    return this.http.post<Novedad>(environment.endpoints.novedades.create,novedad);
   } 
 
   public modificarNew(novedad:Novedad):Observable<Novedad>{
-    return this.http.put<Novedad>(`${this.api}/${novedad.id}`,novedad);
+    return this.http.put<Novedad>(environment.endpoints.novedades.edit(novedad.id),novedad);
   } 
 
   public redireccionar():void{

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import {map} from 'rxjs/operators';
+import { HttpService } from 'src/app/core/services/http.service';
 import { environment } from 'src/environments/environment';
 import { newData, newM, Novedad } from './models/newM';
 
@@ -10,27 +11,26 @@ import { newData, newM, Novedad } from './models/newM';
   providedIn: 'root'
 })
 export class NewsService {
-  private api='https://ongapi.alkemy.org/api/news';
   public novedad!:newData;
-  constructor(private http:HttpClient, private ruta: Router) { }
+  constructor(private http:HttpClient, private ruta: Router, private httpServ:HttpService) { }
 
 
   public verNews():Observable<newData[]>{
-    return this.http.get<newM>(environment.endpoints.novedades.list)
+    return this.httpServ.get<newM>(environment.endpoints.novedades.list)
     .pipe(map((result)=>result.data));
   }
 
   public getNewModel(id:number):Observable<newData>{
-    return this.http.get<any>(environment.endpoints.novedades.detail(id))
+    return this.httpServ.get<any>(environment.endpoints.novedades.detail(id))
     .pipe(map((result)=>result.data));
   }
 
   public deleteNew(id:number):Observable<any>{
-    return this.http.delete<any>(environment.endpoints.novedades.delete(id));
+    return this.httpServ.delete<any>(environment.endpoints.novedades.delete(id));
   }
   
   public nuevaNew(novedad:Novedad):Observable<Novedad>{
-    return this.http.post<Novedad>(environment.endpoints.novedades.create,novedad);
+    return this.httpServ.post<Novedad>(environment.endpoints.novedades.create,novedad);
   } 
 
   public modificarNew(novedad:Novedad):Observable<Novedad>{


### PR DESCRIPTION
### Extender servicio HTTP base para las peticiones de Novedades

COMO: Desarrollador
QUIERO: Centralizar las llamadas a la API
PARA: Poder reutilizar el servicio desde todos los componentes.

Criterios de aceptacion: Crear un controller de Novedades (newsController) con los métodos necesarios para realizar las peticiones de los componentes de Novedades a la API, que este a su vez llame al servicio (httpService) creado anteriormente. Utilizar HTTP Client