### PR TITLE
Ot284 104

### DIFF
--- a/src/app/features/pages/news/news-cards/news-cards.component.ts
+++ b/src/app/features/pages/news/news-cards/news-cards.component.ts
@@ -1,7 +1,8 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
+import { MatAlertErrorComponent } from 'src/app/shared/components/mat-alert-error/mat-alert-error.component';
 import { newData } from '../models/newM';
 import { NewsService } from '../news.service';
 
@@ -14,7 +15,7 @@ export class NewsCardsComponent implements OnInit {
   public newsLista: newData[]=[]
   public newModel!:newData;
   public myTitle:string;
-  constructor(private newsService: NewsService, private ruta:Router) {
+  constructor(private newsService: NewsService, private ruta:Router, public dialog: MatDialog) {
     this.myTitle="Novedades";
   }
 
@@ -28,7 +29,9 @@ export class NewsCardsComponent implements OnInit {
         this.newsLista=Response;
       },
       error:(error:HttpErrorResponse)=>{
-        console.log(error.message)
+        this.dialog.open(MatAlertErrorComponent,{
+          data:{text:"Error al cargar novedades", message:error.message},
+        })
       }
     })
   }

--- a/src/app/features/pages/news/news-details/news-details.component.ts
+++ b/src/app/features/pages/news/news-details/news-details.component.ts
@@ -1,6 +1,8 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
+import { MatAlertErrorComponent } from 'src/app/shared/components/mat-alert-error/mat-alert-error.component';
 import { newData } from '../models/newM';
 import { NewsService } from '../news.service';
 
@@ -15,7 +17,7 @@ export class NewsDetailsComponent implements OnInit {
   public srcImg:string;
   public content:string;
   public isLoading:boolean;
-  constructor(private svc:NewsService, private ruta:ActivatedRoute) {
+  constructor(private svc:NewsService, private ruta:ActivatedRoute, public dialog:MatDialog) {
     this.id=this.getId();
     this.isLoading=true;
    }
@@ -33,7 +35,9 @@ export class NewsDetailsComponent implements OnInit {
         this.content=data.content;
       },
       error:(error:HttpErrorResponse)=>{
-        console.log(error.message);
+        this.dialog.open(MatAlertErrorComponent,{
+          data:{text:"Error al cargar novedad", message:error.message},
+        })
       }
     })
   }

--- a/src/app/features/pages/news/news-form/news-form.component.ts
+++ b/src/app/features/pages/news/news-form/news-form.component.ts
@@ -7,6 +7,8 @@ import { NewsService } from '../news.service';
 import * as ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Swal from 'sweetalert2';
 import Base64UploaderPlugin from 'customBuilder/Base64Upload';
+import { MatAlertErrorComponent } from 'src/app/shared/components/mat-alert-error/mat-alert-error.component';
+import { MatDialog } from '@angular/material/dialog';
 
 
 @Component({
@@ -27,7 +29,7 @@ export class NewsFormComponent implements OnInit {
   public sendForm!:FormGroup;
   public image!:string;
 
-  constructor(private svcNew:NewsService, private ruta:ActivatedRoute, private formBuilder:FormBuilder) {
+  constructor(private svcNew:NewsService, private ruta:ActivatedRoute, private formBuilder:FormBuilder,public dialog:MatDialog) {
     this.newModel={
       id: 0, name: "", slug: null, content: "", image: "", user_id: 0, category_id: 0,
       created_at: "", updated_at: "", deleted_at: null, group_id: null
@@ -61,7 +63,9 @@ export class NewsFormComponent implements OnInit {
           this.sendForm.controls.category_id.setValue(this.newModel.category_id)
         },
         error:(error:HttpErrorResponse)=>{
-          console.log(error.message);
+          this.dialog.open(MatAlertErrorComponent,{
+            data:{text:"Error al cargar novedad", message:error.message},
+          })
         }
       })
     }
@@ -79,7 +83,9 @@ export class NewsFormComponent implements OnInit {
             this.svcNew.redireccionar();
           },
           error:(error:HttpErrorResponse)=>{
-            console.log(error.message);
+            this.dialog.open(MatAlertErrorComponent,{
+              data:{text:"Error al crear novedad", message:error.message},
+            })
           }
         });  
       }else if(metodo='put'){
@@ -94,7 +100,9 @@ export class NewsFormComponent implements OnInit {
             console.log(response);
             this.svcNew.redireccionar();
           },error:(error:HttpErrorResponse)=>{
-            console.log(error.message);
+            this.dialog.open(MatAlertErrorComponent,{
+              data:{text:"Error al modificar novedad", message:error.message},
+            })
           }
         })
       }

--- a/src/app/features/pages/news/news-list/news-list.component.ts
+++ b/src/app/features/pages/news/news-list/news-list.component.ts
@@ -1,6 +1,8 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
+import { MatAlertErrorComponent } from 'src/app/shared/components/mat-alert-error/mat-alert-error.component';
 import Swal from 'sweetalert2';
 import { newData } from '../models/newM';
 import { NewsService } from '../news.service';
@@ -16,7 +18,7 @@ export class NewsListComponent implements OnInit {
   public linkReference: string='CREAR NOVEDAD';
   displayedColumns: string[] = ['demo-image', 'demo-name', 'demo-date', 'demo-delete', 'demo-modify'];
   
-  constructor(private srcNews:NewsService, private ruta:Router) { }
+  constructor(private srcNews:NewsService, private ruta:Router, public dialog: MatDialog) { }
 
   ngOnInit(): void {
     this.verNovedades();
@@ -29,7 +31,9 @@ export class NewsListComponent implements OnInit {
         this.newsList=Response;
       },
       error:(error:HttpErrorResponse)=>{
-        console.log(error.message)
+        this.dialog.open(MatAlertErrorComponent,{
+          data:{text:"Error al cargar novedades", message:error.message},
+        })
       }
     })
   }

--- a/src/app/features/pages/news/news-list/news-list.component.ts
+++ b/src/app/features/pages/news/news-list/news-list.component.ts
@@ -53,7 +53,9 @@ export class NewsListComponent implements OnInit {
             Swal.fire('Deleted!', '', 'success')
           },
           error:(error:HttpErrorResponse)=>{
-            console.log(error.message);
+            this.dialog.open(MatAlertErrorComponent,{
+              data:{text:"Error al eliminar novedad", message:error.message},
+            })
           }
         })
       } else if (result.isDenied) {

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -34,7 +34,7 @@ export class NewsService {
   } 
 
   public modificarNew(novedad:Novedad):Observable<Novedad>{
-    return this.http.put<Novedad>(environment.endpoints.novedades.edit(novedad.id),novedad);
+    return this.httpServ.put<Novedad>(environment.endpoints.novedades.edit(novedad.id),novedad);
   } 
 
   public redireccionar():void{


### PR DESCRIPTION
### Mostrar errores cuando las peticiones no se realicen correctamente
COMO: Usuario
QUIERO: Visualizar errores
PARA: Tener un feedback al realizar una acción

Criterios de aceptacion: Utilizando los componentes reutilizables de dialog, mostrar un error al usuario cuando las peticiones realizadas desde el servicio tengan un error