### PR TITLE
Ot284 173

### DIFF
--- a/src/app/features/pages/news/news-form/news-form.component.html
+++ b/src/app/features/pages/news/news-form/news-form.component.html
@@ -46,7 +46,7 @@
       <mat-form-field appearance="fill">
         <mat-select id="category_id" name="category_id" formControlName="category_id"
           [ngClass]="{'is-invalid':categoria.errors && categoria.touched}">
-          <mat-option *ngFor="let category of categories" [value]="category.id">
+          <mat-option *ngFor="let category of categories$! |async" [value]="category.id">
             {{category.name}}
           </mat-option>
         </mat-select>

--- a/src/app/features/pages/news/news-form/news-form.component.ts
+++ b/src/app/features/pages/news/news-form/news-form.component.ts
@@ -9,6 +9,8 @@ import Swal from 'sweetalert2';
 import Base64UploaderPlugin from 'customBuilder/Base64Upload';
 import { MatAlertErrorComponent } from 'src/app/shared/components/mat-alert-error/mat-alert-error.component';
 import { MatDialog } from '@angular/material/dialog';
+import { Category } from 'src/app/shared/interfaces/category';
+import { NewsCategoriesService } from 'src/app/core/services/news-categories.service';
 
 
 @Component({
@@ -21,15 +23,12 @@ export class NewsFormComponent implements OnInit {
   editorConfig={extraPlugins:[Base64UploaderPlugin]}
   public newModel!: newData;
   private id:number;
-  public categories:any[]=[
-    {id: 2292, name: "Deportes monumento"},
-    {id: 2293, name: "Recaudacion 2022 julio"}
-  ]
+  public categories:Category[]
   public metodo:string="";
   public sendForm!:FormGroup;
   public image!:string;
 
-  constructor(private svcNew:NewsService, private ruta:ActivatedRoute, private formBuilder:FormBuilder,public dialog:MatDialog) {
+  constructor(private srcCategory:NewsCategoriesService,private svcNew:NewsService, private ruta:ActivatedRoute, private formBuilder:FormBuilder,public dialog:MatDialog) {
     this.newModel={
       id: 0, name: "", slug: null, content: "", image: "", user_id: 0, category_id: 0,
       created_at: "", updated_at: "", deleted_at: null, group_id: null
@@ -48,6 +47,13 @@ export class NewsFormComponent implements OnInit {
 
   ngOnInit(): void {
     this.verInputs(this.id);
+    this.getCategories();
+  }
+
+  public getCategories(){
+    this.srcCategory.getCategories().subscribe((categories)=>{
+      this.categories=categories;
+    })
   }
 
   public verInputs(id:number){

--- a/src/app/features/pages/news/news-form/news-form.component.ts
+++ b/src/app/features/pages/news/news-form/news-form.component.ts
@@ -13,6 +13,8 @@ import { AppState } from 'src/app/state/app.state';
 import { getNew, createNew, editNew } from 'src/app/state/actions/news.action';
 import { Observable } from 'rxjs';
 import { selectNewToEdit, selectResponse } from 'src/app/state/selectors/news.selector';
+import { loadCategories } from 'src/app/state/actions/categories.actions';
+import { selectCategories } from 'src/app/state/selectors/categories.selectors';
 
 @Component({
   selector: 'app-news-form',
@@ -24,11 +26,11 @@ export class NewsFormComponent implements OnInit {
   editorConfig={extraPlugins:[Base64UploaderPlugin]}
   public newModel$!: Observable<newData>;
   private id:number;
-  public categories:Category[]
+  public categories$:Observable<Category[]>
   public metodo:string="";
   public sendForm!:FormGroup;
 
-  constructor(private store:Store<AppState>,private router:Router, private ruta:ActivatedRoute, private formBuilder:FormBuilder,public dialog:MatDialog) {
+  constructor(private store:Store<AppState>,private router:Router, private ruta:ActivatedRoute, private formBuilder:FormBuilder,public dialog:MatDialog, private srcCategory:NewsCategoriesService ) {
     this.id=this.ruta.snapshot.params['id'];
     this.metodo="post";
     this.sendForm=this.formBuilder.group(
@@ -44,6 +46,11 @@ export class NewsFormComponent implements OnInit {
   ngOnInit(): void {
     this.getCategories();
     if(this.id!==undefined){
+      this.getNewById();
+    }
+  }
+
+  public getNewById(){
       let id=this.id;
       this.store.dispatch(getNew({id}));
       this.newModel$=this.store.select(selectNewToEdit);
@@ -54,13 +61,11 @@ export class NewsFormComponent implements OnInit {
         this.sendForm.controls.image.setValue(`<figure class="image"><img src="${newM.image}"></figure>`);
         this.sendForm.controls.category_id.setValue(newM.category_id)
       })
-    }
   }
 
   public getCategories(){
-    this.srcCategory.getCategories().subscribe((categories)=>{
-      this.categories=categories;
-    })
+    this.store.dispatch(loadCategories());
+    this.categories$=this.store.select(selectCategories);
   }
 
   public enviarNovedad(metodo:string):void{

--- a/src/app/features/pages/news/news-list/news-list.component.html
+++ b/src/app/features/pages/news/news-list/news-list.component.html
@@ -23,32 +23,32 @@
 <table mat-table class="mat-elevation-z8 demo-table" [dataSource]="newsList$">
     <!--Imagen -->
     <ng-container matColumnDef="demo-image">
-      <th mat-header-cell *matHeaderCellDef> Imagen </th>
+      <th mat-header-cell *matHeaderCellDef> IMAGEN </th>
       <td mat-cell *matCellDef="let new"> <img [src]="new.image"></td>
     </ng-container>
   
     <!-- Name -->
     <ng-container matColumnDef="demo-name">
-      <th mat-header-cell *matHeaderCellDef> Titulo </th>
+      <th mat-header-cell *matHeaderCellDef class="title"> TITULO </th>
       <td mat-cell *matCellDef="let new"> {{new.name}} </td>
     </ng-container>
   
     <!-- Created_At -->
     <ng-container matColumnDef="demo-date">
-      <th mat-header-cell *matHeaderCellDef> Fecha de creación </th>
-      <td mat-cell *matCellDef="let new"> {{new.created_at | date :'dd/MM/yy'}} </td>
-    </ng-container>
-  
-    <!-- Delete action -->
-    <ng-container matColumnDef="demo-delete">
-      <th mat-header-cell *matHeaderCellDef>  </th>
-      <td mat-cell *matCellDef="let new"> <button type="button" (click)="eliminar(new)" mat-raised-button color="warn">ELIMINAR</button></td>
+      <th mat-header-cell *matHeaderCellDef> FECHA DE CREACIÓN </th>
+      <td mat-cell *matCellDef="let new"> {{new.created_at | date :'dd/MM/yyyy'}} </td>
     </ng-container>
 
-    <!-- Modify action -->
-    <ng-container matColumnDef="demo-modify">
-        <th mat-header-cell *matHeaderCellDef> </th>
-        <td mat-cell *matCellDef="let new"> <button type="button" (click)="modificar(new.id)" mat-raised-button color="primary">MODIFICAR</button></td>
+      <ng-container matColumnDef="demo-actions" >
+        <th mat-header-cell *matHeaderCellDef > ACCIONES</th>
+        <td mat-cell *matCellDef="let new">
+          <a mat-icon-button (click)="modificar(new.id)">
+            <mat-icon color="primary">edit</mat-icon>
+          </a>
+          <a mat-icon-button (click)="eliminar(new)">
+            <mat-icon color="warn">delete</mat-icon>
+          </a>
+        </td>
       </ng-container>
   
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/features/pages/news/news-list/news-list.component.html
+++ b/src/app/features/pages/news/news-list/news-list.component.html
@@ -9,7 +9,7 @@
     <mat-form-field appearance="fill" class="categories-field">
       <mat-label>Categoria</mat-label>
       <mat-select [(value)]="selected">
-        <mat-option *ngFor="let category of categoriesList" (onSelectionChange)="searchCat($event)" [value]="category.name">{{category.name}}</mat-option>
+        <mat-option *ngFor="let category of categoriesList$! | async" (onSelectionChange)="searchCat($event)" [value]="category.name">{{category.name}}</mat-option>
         <mat-option value="todas">Todas</mat-option>
       </mat-select>
     </mat-form-field>

--- a/src/app/features/pages/news/news-list/news-list.component.html
+++ b/src/app/features/pages/news/news-list/news-list.component.html
@@ -8,9 +8,8 @@
     -
     <mat-form-field appearance="fill" class="categories-field">
       <mat-label>Categoria</mat-label>
-      <mat-select [(value)]="selected">
-        <mat-option *ngFor="let category of categoriesList$! | async" (onSelectionChange)="searchCat($event)" [value]="category.name">{{category.name}}</mat-option>
-        <mat-option value="todas">Todas</mat-option>
+      <mat-select [(value)]="categoryName">
+        <mat-option *ngFor="let category of categoriesList" (onSelectionChange)="searchCat($event)" [value]="category">{{category}}</mat-option>
       </mat-select>
     </mat-form-field>
 </form>

--- a/src/app/features/pages/news/news-list/news-list.component.html
+++ b/src/app/features/pages/news/news-list/news-list.component.html
@@ -5,6 +5,13 @@
       <mat-label>Busque novedad por título</mat-label>
       <input matInput>
     </mat-form-field>
+    -
+    <mat-form-field appearance="fill" class="categories-field">
+      <mat-label>Categoria</mat-label>
+      <mat-select formControlName="category">
+        <mat-option *ngFor="let category of categoriesList" (onSelectionChange)="searchCat.next($event)" [value]="category">{{category}}</mat-option>
+      </mat-select>
+    </mat-form-field>
 </form>
 
 <div [style.margin.px]="5" class="boton">

--- a/src/app/features/pages/news/news-list/news-list.component.html
+++ b/src/app/features/pages/news/news-list/news-list.component.html
@@ -8,8 +8,9 @@
     -
     <mat-form-field appearance="fill" class="categories-field">
       <mat-label>Categoria</mat-label>
-      <mat-select formControlName="category">
-        <mat-option *ngFor="let category of categoriesList" (onSelectionChange)="searchCat.next($event)" [value]="category">{{category}}</mat-option>
+      <mat-select [(value)]="selected">
+        <mat-option *ngFor="let category of categoriesList" (onSelectionChange)="searchCat($event)" [value]="category.name">{{category.name}}</mat-option>
+        <mat-option value="todas">Todas</mat-option>
       </mat-select>
     </mat-form-field>
 </form>

--- a/src/app/features/pages/news/news-list/news-list.component.scss
+++ b/src/app/features/pages/news/news-list/news-list.component.scss
@@ -51,8 +51,13 @@
 }
 
 .search-field{
-  width: 80%;
+  width: 60%;
   padding-top: 2%;
+}
+
+.categories-search{
+  padding-left: 5%;
+  width: 30%;
 }
 
 //container-news

--- a/src/app/features/pages/news/news-list/news-list.component.scss
+++ b/src/app/features/pages/news/news-list/news-list.component.scss
@@ -6,7 +6,6 @@
   .mat-column-demo-image {
     text-align: center;
     padding-left: 0;
-    font-size: 15px;
     img{
         width: 50vh;
         padding-bottom:2%;
@@ -16,10 +15,19 @@
     }
   }
   
-  .mat-column-demo-name {
+  .mat-column-demo-name{
     width: 30%;
     font-size: 20px;
-    padding-left: 0%;
+    padding-left: 1%;
+  }
+
+  .title{
+    text-align: center;
+    font-size: large;
+  }
+
+  .acciones{
+    text-align: center;
   }
   
   .mat-column-demo-date {
@@ -27,16 +35,9 @@
     font-size: 15px;
   }
   
-  .mat-column-demo-delete {
-    padding-left: 16px;
+  .mat-column-demo-actions{
     text-align: center;
-    font-weight: bold;
-  }
-
-  .mat-column-demo-delete {
-    padding-left: 16px;
-    text-align: center;
-    font-weight: bold;
+    width: 20%;
   }
 
   .boton{
@@ -66,4 +67,11 @@
   margin-top:2%;
   display: flex;
   justify-content: center;
+}
+
+th{
+  background-color: rgb(188, 187, 187);
+  text-align: center;
+  font-size: medium;
+  font-weight: bold;
 }

--- a/src/app/features/pages/news/news-list/news-list.component.ts
+++ b/src/app/features/pages/news/news-list/news-list.component.ts
@@ -13,6 +13,8 @@ import { selectNews } from 'src/app/state/selectors/news.selector';
 import { Observable } from 'rxjs';
 import Swal from 'sweetalert2';
 import { NewsService } from '../news.service';
+import { loadCategories } from 'src/app/state/actions/categories.actions';
+import { selectCategories } from 'src/app/state/selectors/categories.selectors';
 
 @Component({
   selector: 'app-news-list',
@@ -28,14 +30,13 @@ export class NewsListComponent implements OnInit {
   
   constructor(private store:Store<AppState>, private srcNews:NewsService, private ruta:Router, public dialog: MatDialog, private srcCategory:NewsCategoriesService) { }
 
-  categoriesList:Category[];
+  categoriesList$:Observable<Category[]>;
   selected='todas';
   buscador:string='';
 
   public getCategories(){
-    this.srcCategory.getCategories().subscribe((data)=>{
-      this.categoriesList=data;
-    })
+    this.store.dispatch(loadCategories());
+    this.categoriesList$=this.store.select(selectCategories);
   }
 
   public searchCat(event:any){

--- a/src/app/features/pages/news/news-list/news-list.component.ts
+++ b/src/app/features/pages/news/news-list/news-list.component.ts
@@ -28,7 +28,7 @@ export class NewsListComponent implements OnInit {
   public search=new Subject<any>();
   public linkCrear:string='/backoffice/news/create';
   public linkReference: string='CREAR NOVEDAD';
-  displayedColumns: string[] = ['demo-image', 'demo-name', 'demo-date', 'demo-delete', 'demo-modify'];
+  displayedColumns: string[] = ['demo-image', 'demo-name', 'demo-date', 'demo-actions'];
   
   constructor(private store:Store<AppState>, private srcNews:NewsService, private ruta:Router, public dialog: MatDialog, private srcCategory:NewsCategoriesService) { }
 

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -17,7 +17,7 @@ export class NewsService {
 
   public verNews():Observable<any>{
     return this.httpServ.get<newM>(environment.endpoints.novedades.list, false)
-    .pipe(map((result)=>result.data));
+    .pipe(map((result)=>result.data.reverse()));
   }
 
   public getNewModel(id:number):Observable<newData>{
@@ -44,21 +44,21 @@ export class NewsService {
   public buscarNews(text:string):Observable<any>{
     return this.httpServ.get<any>(`${environment.endpoints.novedades.list}?search=${text}`)
     .pipe(
-      map(result=>result.data)
+      map(result=>result.data.reverse())
     )
   }
 
   public buscarNewsWithCateg(text:string,category:string):Observable<any>{
     return this.httpServ.get<any>(`${environment.endpoints.novedades.list}?search=${text}&category=${category}`)
     .pipe(
-      map(result=>result.data)
+      map(result=>result.data.reverse())
     )
   }
 
   public buscarNewsByCatOnly(category:string):Observable<any>{
     return this.httpServ.get<any>(`${environment.endpoints.novedades.list}?category=${category}`)
     .pipe(
-      map(result=>result.data)
+      map(result=>result.data.reverse())
     )
   }
 

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -55,5 +55,12 @@ export class NewsService {
     )
   }
 
+  public buscarNewsByCatOnly(category:string):Observable<any>{
+    return this.httpServ.get<any>(`${environment.endpoints.novedades.list}?category=${category}`)
+    .pipe(
+      map(result=>result.data)
+    )
+  }
+
 
 }

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -15,7 +15,7 @@ export class NewsService {
   constructor(private ruta: Router, private httpServ:HttpService) { }
 
 
-  public verNews():Observable<newData[]>{
+  public verNews():Observable<any>{
     return this.httpServ.get<newM>(environment.endpoints.novedades.list, false)
     .pipe(map((result)=>result.data));
   }

--- a/src/app/features/pages/news/news.service.ts
+++ b/src/app/features/pages/news/news.service.ts
@@ -48,5 +48,12 @@ export class NewsService {
     )
   }
 
+  public buscarNewsWithCateg(text:string,category:string):Observable<any>{
+    return this.httpServ.get<any>(`${environment.endpoints.novedades.list}?search=${text}&category=${category}`)
+    .pipe(
+      map(result=>result.data)
+    )
+  }
+
 
 }


### PR DESCRIPTION
### Filtrar Novedades por categorias & Algunos Ajustes  (Backoffice) 
Se agregó al listado un selector de categorias para poder realizar busqueda de Novedades por titulo y categoria.
Se cargó el selector de categorias obteniendo las mismas desde el backend, agregando la opcion "todas".

- Cuando se seleccionan "todas", se siguen las mismas condiciones que en la busqueda por título.
- Cuando se selecciona una categoria diferente a todas, se realiza la petición al endpoint
-  /news?search={valorBuscado]&category={categoriaSeleccionada}.

Se ajustaron estilos de listado de news en backoffice y se revierte el listado de news en llamados a la api.
