### PR TITLE
Organization & Slides Fixes

### DIFF
--- a/src/app/features/pages/backoffice/organization/edit/edit.component.html
+++ b/src/app/features/pages/backoffice/organization/edit/edit.component.html
@@ -1,9 +1,9 @@
-<form [formGroup]="formOrganization" (ngSubmit)="onSubmit()">
+<form [formGroup]="formOrganization" (ngSubmit)="onSubmit()" #ngForm="ngForm">
   <div class="container">
     <h1>EDITAR ORGANIZACION</h1>
     <img [src]="logo" alt="logo" />
     <mat-form-field class="example-full-width" appearance="fill">
-      <mat-label>Name</mat-label>
+      <mat-label>Nombre</mat-label>
       <input matInput name="name" type="name" formControlName="name" />
     </mat-form-field>
     <div
@@ -13,11 +13,16 @@
         formOrganization.get('name')?.invalid
       "
     >
-      Name is required.
+      El nombre es requerido.
     </div>
     <!-- Acá va Logo y short desc con CKEditor -->
-    <mat-label class="uploadLabel">Upload Logo</mat-label>
-    <input class="fileInput" type="file" formControlName="logo" />
+    <mat-label class="uploadLabel">Cambiar Logo</mat-label>
+    <ckeditor
+      [editor]="Editor"
+      rows="8"
+      formControlName="logo"
+      [config]="editorConfig"
+    ></ckeditor>
     <div
       class="invalid-inputs"
       *ngIf="
@@ -25,7 +30,7 @@
         formOrganization.get('logo')?.invalid
       "
     >
-      Logo is required.
+      El logo es requerido.
     </div>
 
     <mat-label class="uploadLabel">Short Description</mat-label>
@@ -37,7 +42,7 @@
         formOrganization.get('shortDesc')?.invalid
       "
     >
-      Short Description is required.
+      Short Description es requerida.
     </div>
 
     <mat-form-field class="example-full-width" appearance="fill">
@@ -51,7 +56,7 @@
         formOrganization.get('longDesc')?.invalid
       "
     >
-      Long Description is required.
+      Long Description es requerida.
     </div>
 
     <!-- FB, Linkedin, IG, TW -->
@@ -109,8 +114,21 @@
         formOrganization.get('twitter')?.invalid
       "
     >
-      Invalid URL.
+      URL inválida.
     </div>
-    <button type="submit" mat-button color="primary">Enviar</button>
+    <button
+      [disabled]="!formOrganization.valid"
+      type="submit"
+      mat-button
+      color="primary"
+    >
+      Enviar
+    </button>
+    <div
+      class="invalid-inputs"
+      *ngIf="!formOrganization.valid && ngForm.submitted"
+    >
+      Por favor complete todos los campos.
+    </div>
   </div>
 </form>

--- a/src/app/features/pages/backoffice/organization/edit/edit.component.ts
+++ b/src/app/features/pages/backoffice/organization/edit/edit.component.ts
@@ -7,7 +7,9 @@ import {
 } from "@angular/forms";
 import * as ClassicEditor from "@ckeditor/ckeditor5-build-classic";
 import { AboutService } from "src/app/core/services/about.service";
-
+import Base64UploaderPlugin from "customBuilder/Base64Upload";
+import { Router } from "@angular/router";
+import Swal from "sweetalert2";
 @Component({
   selector: "app-edit",
   templateUrl: "./edit.component.html",
@@ -16,15 +18,17 @@ import { AboutService } from "src/app/core/services/about.service";
 export class EditComponent implements OnInit {
   constructor(
     private organization: AboutService,
-    private about: AboutService
+    private about: AboutService,
+    private router: Router
   ) {}
   public Editor = ClassicEditor;
   logo: string;
   id: number;
   urlPattern = "(https?://)?([\\da-z.-]+)\\.([a-z.]{2,6})[/\\w .-]*/?";
+  editorConfig = { extraPlugins: [Base64UploaderPlugin] };
   formOrganization = new FormGroup({
     name: new FormControl("", [Validators.required]),
-    logo: new FormControl("", [Validators.required, this.validExtensions]),
+    logo: new FormControl("", [Validators.required]),
     shortDesc: new FormControl("", [Validators.required]),
     longDesc: new FormControl("", [Validators.required]),
     facebook: new FormControl("", [
@@ -45,17 +49,9 @@ export class EditComponent implements OnInit {
     ]),
   });
 
-  validExtensions(control: AbstractControl) {
-    if (control.value.includes(".jpg") || control.value.includes(".png")) {
-      return null;
-    } else {
-      return { forbbidenExtension: true };
-    }
-  }
-
   onSubmit() {
     const name = this.formOrganization.value.name;
-    const logo = this.formOrganization.value.logo;
+    const logo = this.obtenerImg(this.formOrganization.value.logo);
     const shortDesc = this.formOrganization.value.shortDesc;
     const longDesc = this.formOrganization.value.longDesc;
     const facebook = this.formOrganization.value.facebook;
@@ -67,6 +63,7 @@ export class EditComponent implements OnInit {
       this.about
         .putOrganization(this.id, {
           name: name,
+          logo: logo,
           short_description: shortDesc,
           long_description: longDesc,
           facebook_url: facebook,
@@ -74,10 +71,23 @@ export class EditComponent implements OnInit {
           instagram_url: instagram,
           twitter_url: twitter,
         })
-        .subscribe((data) => {
-          console.log(data);
+        .subscribe({
+          next: () => {
+            Swal.fire({
+              icon: "success",
+              text: "Organizatión editado con éxito",
+            }).then(() => this.router.navigateByUrl("backoffice/organization"));
+          },
+          error: (err) => {
+            console.log(err);
+          },
         });
     }
+  }
+
+  private obtenerImg(image: string) {
+    let str1 = image.split('src="')[1];
+    return (image = str1.split('"')[0]);
   }
 
   ngOnInit(): void {

--- a/src/app/features/pages/backoffice/organization/organization.component.html
+++ b/src/app/features/pages/backoffice/organization/organization.component.html
@@ -1,18 +1,15 @@
-<div class="wrapper">
-  <h1>ORGANIZACION</h1>
-  <div class="container" *ngIf="orgData">
-    <div class="title">
-      {{ orgData.name }}
-    </div>
-    <div class="logo">
-      <img [src]="orgData.logo" alt="" />
-    </div>
-    <div class="description">
-      {{ orgData.short_description }}
-    </div>
-
-    <button mat-button color="primary" routerLink="edit">
-      Formulario de edición
-    </button>
+<div class="container" *ngIf="orgData">
+  <div class="title">
+    {{ orgData.name }}
   </div>
+  <div class="logo">
+    <img [src]="orgData.logo" alt="" />
+  </div>
+  <div class="description">
+    {{ orgData.short_description }}
+  </div>
+
+  <button mat-button color="primary" routerLink="edit">
+    Formulario de edición
+  </button>
 </div>

--- a/src/app/features/pages/backoffice/organization/organization.component.scss
+++ b/src/app/features/pages/backoffice/organization/organization.component.scss
@@ -2,15 +2,6 @@
   font-size: 16px;
 }
 
-.wrapper {
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-}
-
 .container {
   display: flex;
   flex-direction: column;

--- a/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.html
+++ b/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.html
@@ -2,13 +2,13 @@
   <div class="container">
     <h1>Slides</h1>
     <mat-form-field class="example-full-width" appearance="fill">
-      <mat-label>Name</mat-label>
+      <mat-label>Nombre</mat-label>
       <input matInput name="name" type="text" formControlName="name" />
     </mat-form-field>
     <mat-error
       *ngIf="formSlides.get('name')?.touched && formSlides.get('name')?.invalid"
     >
-      Name is required.</mat-error
+      El nombre es requerido.</mat-error
     >
 
     <ckeditor
@@ -16,7 +16,7 @@
       rows="8"
       type="text"
       [config]="{
-        placeholder: 'Description'
+        placeholder: 'Descripción'
       }"
       placeholder="Type the content here!"
       formControlName="desc"
@@ -24,21 +24,38 @@
     <mat-error
       *ngIf="formSlides.get('desc')?.touched && formSlides.get('desc')?.invalid"
     >
-      Description is required.</mat-error
+      La descripción es requerida.</mat-error
     >
 
     <mat-form-field class="example-full-width" appearance="fill">
-      <mat-label>Order</mat-label>
-      <input matInput name="order" type="number" formControlName="order" />
+      <mat-label>Orden</mat-label>
+      <input
+        matInput
+        name="order"
+        type="number"
+        min="1"
+        formControlName="order"
+      />
       <mat-error
         *ngIf="
-          formSlides.get('order')?.touched && formSlides.get('order')?.invalid
+          formSlides.get('order')?.touched &&
+          formSlides.get('order')?.errors?.required
         "
       >
-        Invalid order.</mat-error
+        El orden es inválido.</mat-error
       >
     </mat-form-field>
-    <mat-label>Subir Imagen</mat-label>
+
+    <button
+      (click)="deleteImage()"
+      class="buttonImg"
+      type="button"
+      mat-button
+      color="primary"
+    >
+      Borrar Imagen
+    </button>
+
     <ckeditor
       [editor]="Editor"
       matInput
@@ -51,9 +68,9 @@
         formSlides.get('image')?.touched && formSlides.get('image')?.invalid
       "
     >
-      Image is required.</mat-error
+      La imagen es requerida.</mat-error
     >
 
-    <button type="submit" mat-button color="primary">Submit</button>
+    <button type="submit" mat-button color="primary">Enviar</button>
   </div>
 </form>

--- a/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.scss
+++ b/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.scss
@@ -38,3 +38,8 @@ button:hover {
     rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
     rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
 }
+
+.buttonImg {
+  margin-bottom: -2rem;
+  width: 30%;
+}

--- a/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.ts
+++ b/src/app/features/pages/backoffice/slides/slides-form/slides-form.component.ts
@@ -1,11 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  ElementRef,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from "@angular/core";
+import { AfterViewInit, Component, OnDestroy, OnInit } from "@angular/core";
 import {
   AbstractControl,
   FormControl,
@@ -21,8 +14,7 @@ import { Slides } from "src/app/shared/interfaces/slides";
 import Swal from "sweetalert2";
 import { map } from "rxjs/operators";
 import { SlidesServiceService } from "./slides-service.service";
-
-import { environment } from "src/environments/environment";
+import { Router } from "@angular/router";
 
 @Component({
   selector: "app-slides-form",
@@ -45,7 +37,8 @@ export class SlidesFormComponent implements OnInit, AfterViewInit, OnDestroy {
 
   constructor(
     private slides: NewsSlidesService,
-    private slideForm: SlidesServiceService
+    private slideForm: SlidesServiceService,
+    private router: Router
   ) {}
 
   validExtensions(control: AbstractControl) {
@@ -93,7 +86,7 @@ export class SlidesFormComponent implements OnInit, AfterViewInit, OnDestroy {
               Swal.fire({
                 icon: "success",
                 text: "Slide creada con éxito",
-              });
+              }).then(() => this.router.navigateByUrl("backoffice/slides"));
               console.log(data);
             },
             error: (error) => {
@@ -121,8 +114,7 @@ export class SlidesFormComponent implements OnInit, AfterViewInit, OnDestroy {
               Swal.fire({
                 icon: "success",
                 text: "Slide editada con éxito",
-              });
-              console.log(data);
+              }).then(() => this.router.navigateByUrl("backoffice/slides"));
             },
             error: (error) => {
               console.log(error);
@@ -144,18 +136,8 @@ export class SlidesFormComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  toDataUrl(url: string, callback: any) {
-    const xhr = new XMLHttpRequest();
-    xhr.onload = function () {
-      const reader = new FileReader();
-      reader.onloadend = function () {
-        callback(reader.result);
-      };
-      reader.readAsDataURL(xhr.response);
-    };
-    xhr.open("GET", url);
-    xhr.responseType = "blob";
-    xhr.send();
+  deleteImage() {
+    this.formSlides.controls["image"].setValue("");
   }
 
   private obtenerImg(image: string) {
@@ -176,11 +158,9 @@ export class SlidesFormComponent implements OnInit, AfterViewInit, OnDestroy {
         this.slideForm.editSlideData.order
       );
 
-      const proxyUrl = "https://cors-anywhere.herokuapp.com/",
-        targetUrl = this.slideForm.editSlideData.image;
-      this.toDataUrl(proxyUrl + targetUrl, (data: any) => {
-        this.formSlides.controls.image.setValue(`<img src="${data}"></img>`);
-      });
+      this.formSlides.controls.image.setValue(
+        `<img src="${this.slideForm.editSlideData.image}"></img>`
+      );
 
       this.formSlides.controls["order"].clearValidators();
       this.formSlides.controls["order"].setValidators(Validators.required);

--- a/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.html
+++ b/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.html
@@ -4,35 +4,43 @@
     <!--- Note that these columns can be defined in any order.
           The actual rendered columns are set as a property on the row definition" -->
 
-    <!-- Position Column -->
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Name</th>
-      <td mat-cell *matCellDef="let i">{{ i.name }}</td>
-    </ng-container>
-
     <!-- Name Column -->
     <ng-container matColumnDef="image">
-      <th mat-header-cell *matHeaderCellDef>Image</th>
+      <th mat-header-cell *matHeaderCellDef>Imagen</th>
       <td mat-cell *matCellDef="let i">
-        <img [src]="i.image" alt="" />
+        <div class="cell">
+          <img [src]="i.image" alt="" />
+        </div>
+      </td>
+    </ng-container>
+
+    <!-- Position Column -->
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Nombre</th>
+      <td mat-cell *matCellDef="let i">
+        <div class="cell">{{ i.name }}</div>
       </td>
     </ng-container>
 
     <!-- Weight Column -->
     <ng-container matColumnDef="order">
-      <th mat-header-cell *matHeaderCellDef>Order</th>
-      <td mat-cell *matCellDef="let i">{{ i.order }}</td>
+      <th mat-header-cell *matHeaderCellDef>Orden</th>
+      <td mat-cell *matCellDef="let i">
+        <div class="cell">{{ i.order }}</div>
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef></th>
+      <th mat-header-cell *matHeaderCellDef>Acciones</th>
       <td mat-cell *matCellDef="let i = index">
-        <a mat-icon-button (click)="editSlide(i)">
-          <mat-icon>edit</mat-icon>
-        </a>
-        <a mat-icon-button (click)="deleteSlide(i)">
-          <mat-icon color="warn">delete</mat-icon>
-        </a>
+        <div class="cell">
+          <a mat-icon-button (click)="editSlide(i)">
+            <mat-icon>edit</mat-icon>
+          </a>
+          <a mat-icon-button (click)="deleteSlide(i)">
+            <mat-icon color="warn">delete</mat-icon>
+          </a>
+        </div>
       </td>
     </ng-container>
 

--- a/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.scss
+++ b/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.scss
@@ -22,3 +22,12 @@ table {
 img {
   width: 400px;
 }
+
+.mat-header-cell {
+  text-align: center;
+}
+
+.cell {
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.ts
+++ b/src/app/features/pages/backoffice/slides/slides-view/slides-view.component.ts
@@ -19,13 +19,14 @@ export class SlidesViewComponent implements OnInit {
     private slidesForm: SlidesServiceService,
     private router: Router
   ) {}
-  displayedColumns: string[] = ["name", "image", "order", "actions"];
+  displayedColumns: string[] = ["image", "name", "order", "actions"];
   dataSource = new MatTableDataSource<Slides>();
   row: Slides[];
   routerPath = "create";
-  linkRef = "Create Slide";
+  linkRef = "Crear Slide";
 
   updateTable() {
+    this.row.sort((a: any, b: any) => a.order - b.order);
     this.dataSource.data = this.row;
   }
 
@@ -53,7 +54,7 @@ export class SlidesViewComponent implements OnInit {
 
   editSlide(i: number) {
     this.slidesForm.editSlideData = this.row[i];
-    this.slidesForm.isEditing = true
+    this.slidesForm.isEditing = true;
     this.router.navigateByUrl("backoffice/slides/edit");
   }
 


### PR DESCRIPTION
**Organization**

- Fixes en la muestra los de datos de organizatión
- Ahora se puede editar el logo con ckeditor
- Feedback si el formulario es inválido 
- Navega al home de organización si la edición fue exitosa
- Consistencia de idioma en la tabla y formulario

**Slides**

- Centrado de textos de headear de tabla y datos de API
- Se ordena la tabla con arr.sort() en base al orden de los slides
- Se borró toda la lógica de pasar a base64 con proxy a la hora de editar un slide
- Se agregó botón de borrar imagen en el ckeditor de imagen
- Navega a la tabla de Slides si la creación/edición de slide fue exitosa
- Consistencia de idioma en la tabla y formulario